### PR TITLE
Seeker interface implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ os:
   - osx 
 
 go:
-  - 1.6.x
-  - 1.7.x
   - 1.8.x
   - 1.9.x
+  - 1.10.x
+  - 1.11.x
   - master
 
 script: 

--- a/reader.go
+++ b/reader.go
@@ -280,7 +280,7 @@ func (a *seekable) Seek(offset int64, whence int) (res int64, err error) {
 		for a.cur != nil {
 			if err = a.fill(); err == nil && a.cur != nil {
 				offset -= int64(len(a.cur.buffer()))
-				a.cur.offset=len(a.cur.buf)
+				a.cur.offset = len(a.cur.buf)
 			}
 		}
 	}

--- a/reader.go
+++ b/reader.go
@@ -18,6 +18,13 @@ import (
 	"io"
 )
 
+// Seek whence values.
+const (
+	SeekStart   = 0 // seek relative to the origin of the file
+	SeekCurrent = 1 // seek relative to the current offset
+	SeekEnd     = 2 // seek relative to the end
+)
+
 type ReaderSeekerCloser interface {
 	io.ReadSeeker
 	io.Closer
@@ -260,7 +267,7 @@ func (a *reader) Seek(offset int64, whence int) (res int64, err error) {
 		case a.exit <- struct{}{}:
 			<-a.exited
 		}
-		if whence == io.SeekCurrent {
+		if whence == SeekCurrent {
 			a.fill()
 			//If need to seek based on current position, take into consideration the bytes we read but the consumer
 			//doesn't know about.

--- a/reader_test.go
+++ b/reader_test.go
@@ -84,11 +84,11 @@ func (s *SeekerBuffer) Seek(offset int64, whence int) (res int64, err error) {
 		return
 	}
 	switch whence {
-	case io.SeekStart:
+	case readahead.SeekStart:
 		res = offset
-	case io.SeekCurrent:
+	case readahead.SeekCurrent:
 		res = s.pos + offset
-	case io.SeekEnd:
+	case readahead.SeekEnd:
 		res = s.len + offset
 	}
 	s.pos = res
@@ -114,7 +114,7 @@ func TestSeeker(t *testing.T) {
 		t.Fatal("unexpected length, expected 3, got ", n)
 	}
 
-	pos, err := ar.Seek(1, io.SeekStart)
+	pos, err := ar.Seek(1, readahead.SeekStart)
 	if err != nil {
 		t.Fatal("error when seeking:", err)
 	}
@@ -132,7 +132,7 @@ func TestSeeker(t *testing.T) {
 		t.Fatal("unexpected seeked data, expected est, got ", string(dst))
 	}
 
-	pos, err = ar.Seek(1, io.SeekCurrent)
+	pos, err = ar.Seek(1, readahead.SeekCurrent)
 	if err != nil {
 		t.Fatal("error when seeking:", err)
 	}
@@ -150,7 +150,7 @@ func TestSeeker(t *testing.T) {
 		t.Fatal("unexpected seeked data, expected uff, got ", string(dst))
 	}
 
-	pos, err = ar.Seek(-1, io.SeekEnd)
+	pos, err = ar.Seek(-1, readahead.SeekEnd)
 	if err != nil {
 		t.Fatal("error when seeking:", err)
 	}

--- a/reader_test.go
+++ b/reader_test.go
@@ -67,7 +67,6 @@ func TestReader(t *testing.T) {
 type SeekerBuffer struct {
 	*bytes.Buffer
 	pos int64
-	len int64
 }
 
 func (s *SeekerBuffer) Read(p []byte) (n int, err error) {
@@ -79,7 +78,7 @@ func (s *SeekerBuffer) Read(p []byte) (n int, err error) {
 }
 
 func (s *SeekerBuffer) Seek(offset int64, whence int) (res int64, err error) {
-	if offset > s.len {
+	if offset > int64(s.Len()) {
 		err = fmt.Errorf("wrong offset")
 		return
 	}
@@ -89,7 +88,7 @@ func (s *SeekerBuffer) Seek(offset int64, whence int) (res int64, err error) {
 	case readahead.SeekCurrent:
 		res = s.pos + offset
 	case readahead.SeekEnd:
-		res = s.len + offset
+		res = int64(s.Len()) + offset
 	}
 	s.pos = res
 	return
@@ -98,7 +97,6 @@ func (s *SeekerBuffer) Seek(offset int64, whence int) (res int64, err error) {
 func TestSeeker(t *testing.T) {
 	buf := &SeekerBuffer{
 		Buffer: bytes.NewBufferString("Testbuffer"),
-		len:    10,
 	}
 	ar, err := readahead.NewReadSeekerSize(buf, 4, 10000)
 	if err != nil {

--- a/reader_test.go
+++ b/reader_test.go
@@ -104,7 +104,7 @@ func TestSeeker(t *testing.T) {
 		return buf
 	}
 	for i := 1; i <= 100; i++ {
-		length := len(testBytes) * i*100
+		length := len(testBytes) * i * 100
 		buf := &SeekerBuffer{
 			Buffer: bytes.NewBuffer(testBytes),
 		}


### PR DESCRIPTION
I needed seeking capabilities for a project, so I implemented it.
I was trying to make it in the least "intrusive" way I could think of.

I'm mostly using it with http served contents, and it works well with `Range` requests.

Sadly, the new tests could only run if I had changed the include to my repo. That will need to be changed back after merge.